### PR TITLE
refactor: refine hint suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,4 +14,5 @@
 - Infinite score and improved symbol sizes
 - Highlighting issue when selecting cards
 - Card teleportation during drag-and-drop
+- Hint suggestions now skip redundant moves (e.g., king to empty tableau)
 - GitHub Pages settings for deployment


### PR DESCRIPTION
## Summary
- skip hinting moves that shift a king pile without revealing cards
- avoid hints that move onto a tableau card with identical rank and color
- document refined hint logic in changelog

## Testing
- `node --check js/engine.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5faf3b9b88324bcbef04a4062c80e