### PR TITLE
Add win celebration animation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 - Initial HTML, CSS, and JS files for the Solitaire game
 - Icons displayed on foundation piles
+- Win celebration animation when a game is completed
 
 ### Changed
 - Harmonized event system

--- a/css/style.css
+++ b/css/style.css
@@ -432,3 +432,24 @@ body { -ms-overflow-style: none; scrollbar-width: none; } /* IE/Firefox */
 @container (max-height: 90px){
   .center{ display: none; }
 }
+
+/* ===== Win animation overlay ===== */
+.win-animation{
+  /* full-screen overlay that ignores pointer events */
+  position:fixed;
+  inset:0;
+  pointer-events:none;
+  overflow:hidden;
+  z-index:3000;
+}
+.win-animation .celebration-card{
+  /* cards start just above the viewport */
+  position:absolute;
+  top:calc(var(--card-h) * -1);
+  /* fall with a bit of horizontal drift and rotation */
+  animation: win-fall 3s linear forwards;
+}
+@keyframes win-fall{
+  from{ transform:translate(0,0) rotate(0deg); opacity:1; }
+  to{ transform:translate(var(--dx,0), calc(100vh + var(--card-h))) rotate(var(--rot,720deg)); opacity:0; }
+}

--- a/js/main.js
+++ b/js/main.js
@@ -164,6 +164,9 @@
           stopTimer();                 // freeze timer at win time
           setActionButtonsVisible(false); // hide undo/redo/hint buttons
           UI.toast("You win!");       // notify player
+          if (settings.animations && UI.winAnimation) {
+            UI.winAnimation();        // celebrate with falling cards
+          }
         });
         Engine.on && Engine.on("stuck",() => UI.toast("No moves. Stuck."));
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -162,6 +162,35 @@ function hideBanner(){
   // laisse le texte pour accessibilité; remettra à jour au prochain show
 }
 
+// Simple win celebration: shower the screen with cards
+function winAnimation(){
+  // Overlay to hold temporary animated cards
+  const overlay = document.createElement("div");
+  overlay.className = "win-animation";
+  document.body.appendChild(overlay);
+
+  const suits = ["S","H","D","C"];
+
+  // Generate a full deck of face-up cards
+  for (const suit of suits){
+    for (let rank = 1; rank <= 13; rank++){
+      const card = makeCardEl({ suit, rank, faceUp:true }, 0, { kind:"foundation", cards:[] });
+      card.classList.add("celebration-card");
+      overlay.appendChild(card);
+
+      // Random horizontal start position and drift/rotation via CSS vars
+      const w = card.getBoundingClientRect().width;
+      card.style.left = Math.random() * (window.innerWidth - w) + "px";
+      card.style.setProperty("--dx", (Math.random()*200 - 100) + "px");
+      card.style.setProperty("--rot", (Math.random()*720 + 360) + "deg");
+      card.style.animationDelay = (Math.random()*0.5) + "s";
+    }
+  }
+
+  // Clean up after animations finish
+  setTimeout(() => overlay.remove(), 4000);
+}
+
 function highlightMove(move){
   clearValidTargets();
   if (!move) return;
@@ -355,7 +384,7 @@ function onCardTap(e){
 }
 
 
-    return { ...api, init, render, toast, applyDeltas, updateStatus, highlightMove };
+    return { ...api, init, render, toast, applyDeltas, updateStatus, highlightMove, winAnimation };
   })();
 
   window.UI = UI;


### PR DESCRIPTION
## Summary
- shower screen with falling cards when a game is won
- support optional animation via `settings.animations`
- document new celebration in changelog

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b604ee48f083248c041295e7ca60cc