### PR TITLE
Animate auto-complete moves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Icons displayed on foundation piles
 - Win celebration animation when a game is completed
 - Auto-complete option to finish when only foundation moves remain
+- Cards visibly travel from source to foundation during auto-complete when animations are enabled
 
 ### Changed
 - Harmonized event system

--- a/js/main.js
+++ b/js/main.js
@@ -171,9 +171,17 @@
       const step = () => {
         const move = Engine.findHint && Engine.findHint();
         if (move && move.dstPileId.startsWith("foundation")){
-          Engine.move(move);
-          const delay = settings.animations ? 200 : 0;
-          setTimeout(step, delay);
+          // When animations are enabled, visually move the card first
+          if (settings.animations && UI.animateMove){
+            UI.animateMove(move).then(() => {
+              Engine.move(move);
+              setTimeout(step, 0); // next step immediately after rendering
+            });
+          } else {
+            Engine.move(move);
+            const delay = settings.animations ? 200 : 0;
+            setTimeout(step, delay);
+          }
         }
       };
 

--- a/js/ui.js
+++ b/js/ui.js
@@ -203,6 +203,52 @@ function highlightMove(move){
   setTimeout(()=>{ srcEl?.classList.remove('hint'); dstEl?.classList.remove('valid-target'); dstPile?.classList.remove('valid-target'); }, 1500);
 }
 
+/**
+ * Animate a card flying from its source pile to a destination pile.
+ * This helper clones the DOM node so the real card can remain in place
+ * until the Engine updates the state. The clone is positioned using a
+ * simple FLIP (First, Last, Invert, Play) transition.
+ * @param {{srcPileId:string, cardIndex:number, dstPileId:string}} move
+ * @param {number} [ms=200] duration of the animation
+ * @returns {Promise<void>} resolves once the animation finishes
+ */
+function animateMove(move, ms = 200){
+  return new Promise(resolve => {
+    const srcPile = document.getElementById(move.srcPileId);
+    const dstPile = document.getElementById(move.dstPileId);
+    const srcEl = srcPile?.querySelectorAll('.card')[move.cardIndex];
+    if (!srcEl || !dstPile){ resolve(); return; }
+
+    // Starting and ending geometry
+    const start = srcEl.getBoundingClientRect();
+    const end   = dstPile.getBoundingClientRect();
+
+    // Clone the card so the original can be hidden during the flight
+    const ghost = srcEl.cloneNode(true);
+    ghost.style.position = 'fixed';
+    ghost.style.left = start.left + 'px';
+    ghost.style.top  = start.top + 'px';
+    ghost.style.margin = '0';
+    ghost.style.transition = `transform ${ms}ms ease`;
+    document.body.appendChild(ghost);
+    srcEl.style.visibility = 'hidden';
+
+    // Play the animation on the next frame
+    requestAnimationFrame(() => {
+      const dx = end.left - start.left;
+      const dy = end.top  - start.top;
+      ghost.style.transform = `translate(${dx}px, ${dy}px)`;
+    });
+
+    // Cleanup after the animation completes
+    setTimeout(() => {
+      ghost.remove();
+      srcEl.style.visibility = '';
+      resolve();
+    }, ms);
+  });
+}
+
 
 
     // ---------- Click interactions
@@ -384,7 +430,7 @@ function onCardTap(e){
 }
 
 
-    return { ...api, init, render, toast, applyDeltas, updateStatus, highlightMove, winAnimation };
+    return { ...api, init, render, toast, applyDeltas, updateStatus, highlightMove, winAnimation, animateMove };
   })();
 
   window.UI = UI;


### PR DESCRIPTION
## Summary
- animate cards traveling to foundations during auto-complete when animations are on
- expose `UI.animateMove` helper
- document animated auto-complete in changelog

## Testing
- `npm test` *(fails: could not find package.json)*
- `node --check js/ui.js`
- `node --check js/main.js`


------
https://chatgpt.com/codex/tasks/task_e_68b60e1d577c8324af183fe048109869