### PR TITLE
fix: load solver script for no-hope hints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,3 +21,4 @@
 - Hint suggestions now skip redundant moves (e.g., king to empty tableau)
 - GitHub Pages settings for deployment
 - Redeal limits now enforced for 1 or 3 redeal options
+- Deterministic solver script now loaded to enable "no hope" hints

--- a/index.html
+++ b/index.html
@@ -225,6 +225,8 @@
     <script src="js/model.js"></script>
     <script src="js/emitter.js"></script>
     <script src="js/engine.js"></script>
+    <!-- Deterministic solver for dead-end detection -->
+    <script src="js/solver.js"></script>
     <script src="js/ui.js"></script>
     <script src="js/main.js"></script>
   </body>


### PR DESCRIPTION
## Summary
- include deterministic solver script so browser can show "no hope" hint message
- document solver loading in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b70781f48c83249f27806923f80d79