### PR TITLE
test: expand coverage and add CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main, develop]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm install
+      - run: npm test

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -30,6 +30,7 @@ Please read the following guidelines before opening an issue or submitting a pul
 3. **Lint / Test** locally before committing:
    - Ensure the game loads cleanly in at least one modern desktop browser and one mobile browser.
    - Avoid console errors/warnings.
+   - Add unit tests for all code-based parts that are testable and keep them passing (`npm test`).
 4. **Commit** using clear messages:
    ```
    feat: add auto-move to foundations

--- a/test/emitter.test.js
+++ b/test/emitter.test.js
@@ -1,0 +1,27 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const context = { window: {}, console };
+context.window = context;
+vm.createContext(context);
+
+const code = fs.readFileSync(new URL('../js/emitter.js', import.meta.url), 'utf8');
+vm.runInContext(code, context, { filename: 'js/emitter.js' });
+
+const { EventEmitter } = context.window;
+
+test('EventEmitter emits to registered listeners', () => {
+  const emitter = EventEmitter();
+  let payload = 0;
+  emitter.on('ping', (n) => { payload = n; });
+  emitter.emit('ping', 7);
+  assert.equal(payload, 7);
+});
+
+test('EventEmitter does not throw when a listener errors', () => {
+  const emitter = EventEmitter();
+  emitter.on('boom', () => { throw new Error('fail'); });
+  assert.doesNotThrow(() => emitter.emit('boom'));
+});

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -1,0 +1,55 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const context = { window: {}, console };
+context.window = context;
+vm.createContext(context);
+
+for (const file of ['js/emitter.js', 'js/model.js', 'js/engine.js']) {
+  const code = fs.readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
+  vm.runInContext(code, context, { filename: file });
+}
+
+const { Engine, Model } = context.window;
+
+function card(s, r, faceUp=true){
+  return { id: s + r, rank: r, suit: s, color: Model.isRed(s) ? 'red':'black', faceUp };
+}
+
+test('Engine.isWin detects full foundations', () => {
+  const foundations = ['S','H','D','C'].map(s => ({ id: 'foundation-'+s, kind: 'foundation', suit: s, cards: Array.from({length:13}, (_,i)=>card(s,i+1)) }));
+  const st = {
+    piles: {
+      foundations,
+      tableau: Array.from({length:7}, (_,i)=>({ id: 'tab-'+(i+1), kind:'tableau', col:i+1, cards:[] })),
+      stock: { id:'stock', kind:'stock', cards:[] },
+      waste: { id:'waste', kind:'waste', cards:[] }
+    }
+  };
+  assert.equal(Engine.isWin(st), true);
+});
+
+test('Engine.enumerateAutoSafeFoundationMoves finds safe waste moves', () => {
+  const foundations = [
+    { id:'foundation-S', kind:'foundation', suit:'S', cards:[card('S',1)] },
+    { id:'foundation-H', kind:'foundation', suit:'H', cards:[] },
+    { id:'foundation-D', kind:'foundation', suit:'D', cards:[] },
+    { id:'foundation-C', kind:'foundation', suit:'C', cards:[] }
+  ];
+  const st = {
+    piles: {
+      foundations,
+      tableau: Array.from({length:7}, (_,i)=>({ id:'tab-'+(i+1), kind:'tableau', col:i+1, cards:[] })),
+      stock: { id:'stock', kind:'stock', cards:[] },
+      waste: { id:'waste', kind:'waste', cards:[card('S',2)] }
+    },
+    settings: {}
+  };
+  const moves = Engine.enumerateAutoSafeFoundationMoves(st);
+  assert.equal(
+    JSON.stringify(moves),
+    JSON.stringify([{ type:'move', src:'waste', cardIndex:0, dst:'foundation-S' }])
+  );
+});

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const context = { window: {}, console };
+context.window = context;
+vm.createContext(context);
+
+const code = fs.readFileSync(new URL('../js/model.js', import.meta.url), 'utf8');
+vm.runInContext(code, context, { filename: 'js/model.js' });
+
+const { Model } = context.window;
+
+function card(s, r, faceUp=true){
+  return { id: s + r, suit: s, rank: r, color: Model.isRed(s) ? 'red':'black', faceUp };
+}
+
+test('newOrderedDeck creates 52 unique cards', () => {
+  const deck = Model.newOrderedDeck();
+  assert.equal(deck.length, 52);
+  const ids = new Set(deck.map(c => c.id));
+  assert.equal(ids.size, 52);
+});
+
+test('shuffle with seeded generator is deterministic', () => {
+  const arr1 = [1,2,3,4,5,6,7,8,9,10];
+  const arr2 = [1,2,3,4,5,6,7,8,9,10];
+  const s1 = Model.shuffle(arr1.slice(), Model.lcg(123));
+  const s2 = Model.shuffle(arr2.slice(), Model.lcg(123));
+  assert.deepStrictEqual(s1, s2);
+});
+
+test('canDropOnTableau and canDropOnFoundation obey rules', () => {
+  const kS = card('S',13);
+  assert.equal(Model.canDropOnTableau(kS, null), true);
+  const qH = card('H',12);
+  assert.equal(Model.canDropOnTableau(qH, kS), true);
+  const aC = card('C',1);
+  assert.equal(Model.canDropOnFoundation(aC, null, 'C'), true);
+  const twoC = card('C',2);
+  assert.equal(Model.canDropOnFoundation(twoC, aC, 'C'), true);
+  const wrongSuit = card('D',2);
+  assert.equal(Model.canDropOnFoundation(wrongSuit, aC, 'C'), false);
+});

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,0 +1,34 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+const localStub = {
+  data: {},
+  getItem(k){ return this.data[k] ?? null; },
+  setItem(k,v){ this.data[k] = String(v); },
+  removeItem(k){ delete this.data[k]; }
+};
+
+const context = { window: {}, console, localStorage: localStub };
+context.window = context;
+vm.createContext(context);
+
+const code = fs.readFileSync(new URL('../js/store.js', import.meta.url), 'utf8');
+vm.runInContext(code, context, { filename: 'js/store.js' });
+
+const { Store } = context.window;
+
+test('Store persists settings via localStorage', () => {
+  Store.setSettings({ a:1 });
+  assert.equal(localStub.data['solitaire.settings'], JSON.stringify({ a:1 }));
+  const st = Store.getSettings();
+  assert.equal(JSON.stringify(st), JSON.stringify({ a:1 }));
+});
+
+test('Store clears saved state', () => {
+  Store.saveState({ foo:'bar' });
+  assert.ok(localStub.data['solitaire.saved']);
+  Store.clearSavedState();
+  assert.equal(localStub.data['solitaire.saved'], undefined);
+});


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests on pull requests and pushes
- expand unit test coverage for emitter, engine, model, and store modules
- document requirement to add unit tests for testable code

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b74618b54883248c4ae25e37efcc01