### PR TITLE
Improve stats panel styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -734,6 +734,34 @@ body {
   }
 }
 
+/* ===== Stats panel ===== */
+#statsPanel {
+  /* centered overlay with dark translucent background */
+  position: fixed;
+  top: 10%;
+  left: 50%;
+  transform: translateX(-50%);
+  max-width: 90%;
+  padding: 1em;
+  background: rgba(0, 0, 0, 0.85);
+  color: #fff;
+  border: var(--line) solid var(--outline);
+  border-radius: var(--radius);
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.4);
+  z-index: 1000;
+  display: none; /* hidden until toggled */
+}
+#statsPanel p {
+  margin: 0.25em 0;
+}
+#statsPanel .stats-actions {
+  margin-top: 0.5em;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em;
+  justify-content: center;
+}
+
 /* ===== Win animation overlay ===== */
 .win-animation {
   /* full-screen overlay that ignores pointer events */

--- a/js/stats-ui.js
+++ b/js/stats-ui.js
@@ -14,11 +14,17 @@
     return m+":"+ss;
   }
 
-  // Build panel DOM once
+  // Build panel DOM once. Styling is defined in css/style.css for maintainability.
   const panel = document.createElement('div');
   panel.id = 'statsPanel';
-  panel.style.cssText = 'position:fixed;top:10%;left:50%;transform:translateX(-50%);background:#fff;padding:1em;border:1px solid #333;max-width:90%;z-index:1000;display:none;';
-  panel.innerHTML = '<div id="statsContent"></div>\n<div style="margin-top:0.5em;">\n  <button id="statsExport">Export</button>\n  <button id="statsImport">Import</button>\n  <button id="statsReset">Reset</button>\n  <button id="statsClose">Close</button>\n</div>';
+  panel.innerHTML = `
+    <div id="statsContent"></div>
+    <div class="stats-actions">
+      <button id="statsExport" class="btn">Export</button>
+      <button id="statsImport" class="btn">Import</button>
+      <button id="statsReset" class="btn">Reset</button>
+      <button id="statsClose" class="btn">Close</button>
+    </div>`;
   document.body.appendChild(panel);
 
   function render(){


### PR DESCRIPTION
## Summary
- move stats panel inline styles to dedicated CSS rules
- refresh stats panel colors for better contrast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b75c1af43083249a945e1c97264544