### PR TITLE
fix: block iOS Safari edge swipe in game area

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -84,6 +84,7 @@ h1 {
   padding: var(--gap);
   max-width: 1200px;
   margin: 0 auto;
+  touch-action: none; /* Capture touches to prevent iOS Safari swipe-back */
 }
 .stock-row {
   display: grid;

--- a/js/main.js
+++ b/js/main.js
@@ -39,24 +39,29 @@
   });
 
   // ---------- DOM refs
-  const refs = {
-    root: $("#game"),
-    score: $("#score"),
-    moves: $("#moves"),
-    time: $("#time"),
-    btnNew: $("#newGame"),
-    btnUndo: $("#undo"),
-    btnRedo: $("#redo"),
-    btnHint: $("#hint"),
-    btnAuto: $("#auto"),
-    selDraw: $("#drawCount"),
-    selRedeal: $("#redealPolicy"),
-    chkLeft: $("#leftHandMode"),
-    chkHints: $("#hints"),
-    chkAuto: $("#autoComplete"),
-    chkAnim: $("#animations"),
-    chkSound: $("#sound"),
-  };
+const refs = {
+  root: $("#game"),
+  score: $("#score"),
+  moves: $("#moves"),
+  time: $("#time"),
+  btnNew: $("#newGame"),
+  btnUndo: $("#undo"),
+  btnRedo: $("#redo"),
+  btnHint: $("#hint"),
+  btnAuto: $("#auto"),
+  selDraw: $("#drawCount"),
+  selRedeal: $("#redealPolicy"),
+  chkLeft: $("#leftHandMode"),
+  chkHints: $("#hints"),
+  chkAuto: $("#autoComplete"),
+  chkAnim: $("#animations"),
+  chkSound: $("#sound"),
+};
+
+  // Capture touch gestures inside the game area to avoid iOS Safari
+  // interpreting left-edge drags as history navigation or tab switching.
+  on(refs.root, "touchstart", (ev) => ev.preventDefault(), { passive: false });
+  on(refs.root, "touchmove", (ev) => ev.preventDefault(), { passive: false });
 
   // ---------- Controller
   const Controller = (() => {


### PR DESCRIPTION
## Summary
- prevent iOS Safari back/tab gestures from hijacking card drags
- document the edge-swipe workaround in code comments

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b8963f795c8324a0660de3ca2d1a98