### PR TITLE
chore: enable browser env for eslint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "env": {
     "es2022": true,
-    "node": true
+    "node": true,
+    "browser": true
   },
   "extends": [
     "eslint:recommended",

--- a/test/emitter.test.js
+++ b/test/emitter.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';

--- a/test/engine.test.js
+++ b/test/engine.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';

--- a/test/findHint.test.js
+++ b/test/findHint.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';

--- a/test/solver.test.js
+++ b/test/solver.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';

--- a/test/stats.test.js
+++ b/test/stats.test.js
@@ -1,55 +1,62 @@
-/* eslint-disable no-console */
+import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import vm from 'node:vm';
 
+// Use the global object to simulate a browser-like environment
 global.window = global;
 const store = {};
-class QuotaError extends Error { constructor(){super('QuotaExceededError'); this.name='QuotaExceededError';} }
+class QuotaError extends Error {
+  constructor(){
+    super('QuotaExceededError');
+    this.name = 'QuotaExceededError';
+  }
+}
 let quotaFail = false;
 
+// Simple localStorage stub for testing persistence
 global.localStorage = {
   getItem(k){ return Object.prototype.hasOwnProperty.call(store,k)?store[k]:null; },
   setItem(k,v){ if(quotaFail){ quotaFail=false; throw new QuotaError(); } store[k]=v; },
   removeItem(k){ delete store[k]; }
 };
 
-// load stats.js into context
+// Load stats.js into the global context so SoliStats is available
 const code = fs.readFileSync(new URL('../js/stats.js', import.meta.url), 'utf8');
 vm.runInThisContext(code);
 const S = global.SoliStats;
 
-// test fresh init and commit
-S.initStats({n:5,k:1});
-S.saveCurrent({ts:0,dr:1,mv:0,rv:0,ru:0,fu:[0,0,0,0],um:0});
-S.commitResult({ts:0,te:1,w:1,m:50,t:100,dr:1,sc:500,rv:0,fu:[13,13,13,13],ab:'none'});
-S.commitResult({ts:2,te:3,w:0,m:40,t:200,dr:3,sc:300,rv:1,fu:[5,4,3,2],ab:'block'});
-let agg = S.loadAgg().g;
-assert.equal(agg.played,2);
-assert.equal(agg.wins,1);
-assert.equal(agg.winStreak,0);
-assert.equal(agg.bestStreak,1);
+test('SoliStats aggregates and persists statistics', () => {
+  // Fresh init and commit two results
+  S.initStats({n:5,k:1});
+  S.saveCurrent({ts:0,dr:1,mv:0,rv:0,ru:0,fu:[0,0,0,0],um:0});
+  S.commitResult({ts:0,te:1,w:1,m:50,t:100,dr:1,sc:500,rv:0,fu:[13,13,13,13],ab:'none'});
+  S.commitResult({ts:2,te:3,w:0,m:40,t:200,dr:3,sc:300,rv:1,fu:[5,4,3,2],ab:'block'});
+  let agg = S.loadAgg().g;
+  assert.equal(agg.played,2);
+  assert.equal(agg.wins,1);
+  assert.equal(agg.winStreak,0);
+  assert.equal(agg.bestStreak,1);
 
-// histogram boundaries
-const bucketsT = agg.histT.reduce((a,b)=>a+b,0);
-assert.equal(bucketsT,2);
+  // Histogram boundaries
+  const bucketsT = agg.histT.reduce((a,b)=>a+b,0);
+  assert.equal(bucketsT,2);
 
-// ring buffer truncation
-for(let i=0;i<10;i++){
-  S.commitResult({ts:10+i,te:11+i,w:0,m:10,t:10,dr:1,sc:0,rv:0,fu:[0,0,0,0],ab:'user'});
-}
-const sessions = S.loadSessions();
-assert.ok(sessions.length <= 5);
+  // Ring buffer truncation
+  for(let i=0;i<10;i++){
+    S.commitResult({ts:10+i,te:11+i,w:0,m:10,t:10,dr:1,sc:0,rv:0,fu:[0,0,0,0],ab:'user'});
+  }
+  const sessions = S.loadSessions();
+  assert.ok(sessions.length <= 5);
 
-// quota simulation
-quotaFail=true;
-S.safeSet('soli.v1.current',{a:1}); // should handle quota and not throw
+  // Quota simulation
+  quotaFail = true;
+  S.safeSet('soli.v1.current',{a:1}); // should handle quota and not throw
 
-// export/import
-const exp = S.exportAll();
-S.initStats({n:5,k:1});
-S.importAll(exp,'replace');
-agg = S.loadAgg().g;
-assert.equal(agg.played, sessions.length);
-
-console.log('stats tests passed');
+  // Export/import round trip
+  const exp = S.exportAll();
+  S.initStats({n:5,k:1});
+  S.importAll(exp,'replace');
+  agg = S.loadAgg().g;
+  assert.equal(agg.played, sessions.length);
+});

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-console */
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';


### PR DESCRIPTION
## Summary
- enable browser environment in ESLint configuration to lint window and document references
- remove obsolete lint overrides and align stats test with node's test runner

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js after dependency install was blocked)*
- `npm install` *(fails: 403 Forbidden when fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aa89f06c83249603e5a12e932758