### PR TITLE
fix: enable desktop double-click auto-move

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -355,7 +355,12 @@
         return;
       }
 
-      ev.preventDefault();
+      // Only prevent default browser behavior for non-mouse pointers.
+      // Preventing default on mouse would cancel native dblclick events.
+      if (ev.pointerType !== "mouse") {
+        // Touch inputs need default prevented to avoid scrolling during drag.
+        ev.preventDefault();
+      }
       ev.stopPropagation();
 
       // bounding rect of the origin card


### PR DESCRIPTION
## Summary
- avoid preventing default mouse behavior during drag start so dblclick events fire

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b3ee47908324b30cb243a211c353