### PR TITLE
build: restore browser env for ESLint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,7 @@
 {
   "root": true,
   "env": {
+    "browser": true,
     "es2021": true,
     "node": true,
     "jest": true


### PR DESCRIPTION
## Summary
- restore `browser` environment in ESLint config alongside Node and Jest

## Testing
- `npm test`
- ⚠️ `npm run lint` *(fails: ESLint 9 expects eslint.config.js and dev dependencies cannot be installed due to 403 error)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bc63f258832485f428a510a0fb1a