### PR TITLE
Add Jest tests for Auto foundation logic and UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Added
 
 - Sequential animations for automatic foundation moves
+- Jest-based deterministic tests for Auto foundation behavior and UI
 
 ### Changed
 
@@ -12,6 +13,7 @@
 - Auto button no longer hangs; auto-play now moves safe cards to foundations deterministically and terminates
 - Auto now moves any legal next-rank card to its foundation (e.g., 3 onto 2)
 - Auto now moves Aces to empty suit foundations and includes comprehensive foundation tests
+- Auto runner guarded against re-entrancy and infinite loops
 
 ## [0.1.0] - 2025-09-03
 

--- a/docs/DEBUG.md
+++ b/docs/DEBUG.md
@@ -3,8 +3,9 @@
 ## Auto-play logging
 
 Set `window.DEBUG_AUTO = true` in the browser console before starting auto-play.
-When enabled, each auto-play iteration logs the current state hash, candidate
-moves, and progress counters to the developer console.
+When enabled, each auto-play iteration logs the current state hash, the list of
+candidate moves, and the move that was applied. Output uses `console.debug` so
+production builds remain silent.
 
 ## Disable auto-play animations
 

--- a/docs/OPTIONS.md
+++ b/docs/OPTIONS.md
@@ -1,0 +1,11 @@
+# Options
+
+## Auto
+
+The Auto feature moves any legal next-rank card to its suit foundation.
+
+- **Sources scanned**: waste top first, then tableau columns left-to-right.
+- **Legal move**: same suit and rank exactly one higher; an empty foundation accepts only the Ace of that suit.
+- **Tableau**: Auto never moves cards between tableau piles. After moving from a tableau column, the newly exposed face-down card flips up if allowed.
+- **Termination**: Auto loops until a full pass finds no moves or iteration/move caps (1000/500) trigger.
+- **Animation**: Moves animate sequentially when animations are enabled. Set `AUTO_ANIMATE=false` to skip animation during tests.

--- a/js/engine.js
+++ b/js/engine.js
@@ -657,8 +657,8 @@
           const next = findNextFoundationMoves(state);
           if (!next.length) break;
           const mv = next[0];
-          // Log iteration, current state hash, and chosen move when debugging
-          logAuto("iter", iterations + 1, "hash", hash, "move", mv);
+          // Log iteration, state hash, available moves, and chosen move when debugging
+          logAuto("iter", iterations + 1, "hash", hash, "moves", next, "applying", mv);
           let p = Promise.resolve();
           if (animate && globalThis.UI?.animateMove)
             p = globalThis.UI.animateMove(mv, animMs);

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test test/*.test.js",
+    "test:auto": "jest tests/auto.spec.js tests/auto.ui.spec.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format": "prettier -w .",
@@ -14,6 +15,8 @@
     "eslint": "8.57.1",
     "eslint-plugin-promise": "6.6.0",
     "jsdom": "^24.0.0",
+    "jest": "^29.7.0",
+    "@jest/globals": "^29.7.0",
     "nyc": "^15.1.0",
     "prettier": "3.6.2"
   },

--- a/tests/auto.spec.js
+++ b/tests/auto.spec.js
@@ -1,0 +1,88 @@
+// Jest unit tests covering the Auto foundation feature
+import { describe, test, expect, beforeEach } from '@jest/globals';
+import { Engine, build } from './helpers/stateBuilder.js';
+
+// Reset to a clean state before each test
+beforeEach(() => {
+  Engine.newGame();
+});
+
+describe('Auto foundation moves', () => {
+  test('moves ace from waste', async () => {
+    const st = build({ waste: ['H1'] });
+    const res = await Engine.runAutoToFixpoint();
+    expect(res.moves).toBe(1);
+    const hf = st.piles.foundations.find((f) => f.suit === 'H');
+    expect(hf.cards).toHaveLength(1);
+    expect(hf.cards[0].rank).toBe(1);
+  });
+
+  test('moves ace from tableau and flips underlying card', async () => {
+    const st = build({ tableau: [['h5', 'S1']] });
+    const res = await Engine.runAutoToFixpoint();
+    expect(res.moves).toBe(1);
+    const sf = st.piles.foundations.find((f) => f.suit === 'S');
+    expect(sf.cards).toHaveLength(1);
+    expect(st.piles.tableau[0].cards[0].faceUp).toBe(true);
+  });
+
+  test('moves 3 on 2', async () => {
+    const st = build({ foundations: { H: ['H1', 'H2'] }, tableau: [['H3']] });
+    const res = await Engine.runAutoToFixpoint();
+    expect(res.moves).toBe(1);
+    const hf = st.piles.foundations.find((f) => f.suit === 'H');
+    expect(hf.cards.map((c) => c.rank)).toEqual([1, 2, 3]);
+  });
+
+  test('chains from ace to three', async () => {
+    const st = build({ waste: ['H1'], tableau: [['H2'], ['H3']] });
+    const res = await Engine.runAutoToFixpoint();
+    expect(res.moves).toBe(3);
+    const hf = st.piles.foundations.find((f) => f.suit === 'H');
+    expect(hf.cards.map((c) => c.rank)).toEqual([1, 2, 3]);
+  });
+
+  test('multiple suits deterministic order', async () => {
+    // Waste should be processed before tableau columns (left to right)
+    const st = build({ waste: ['D1'], tableau: [['C1'], ['S1']] });
+    const moves = Engine._findNextFoundationMoves(st);
+    expect(moves.map((m) => m.from)).toEqual(['waste', 'tab-1', 'tab-2']);
+    await Engine.runAutoToFixpoint();
+    const [sf, hf, df, cf] = st.piles.foundations;
+    expect(sf.cards).toHaveLength(1); // Spades from tableau[1]
+    expect(hf.cards).toHaveLength(0); // No hearts moved
+    expect(df.cards).toHaveLength(1); // Diamond from waste
+    expect(cf.cards).toHaveLength(1); // Club from tableau[0]
+    expect(st.piles.waste.cards).toHaveLength(0);
+  });
+
+  test('no illegal jump', async () => {
+    const st = build({ waste: ['H4'], foundations: { H: ['H1', 'H2'] } });
+    const res = await Engine.runAutoToFixpoint();
+    expect(res.moves).toBe(0);
+    const hf = st.piles.foundations.find((f) => f.suit === 'H');
+    expect(hf.cards.map((c) => c.rank)).toEqual([1, 2]);
+    expect(st.piles.waste.cards[0].rank).toBe(4);
+  });
+
+  test('idempotent and terminates', async () => {
+    const st = build({ waste: ['H1'] });
+    const r1 = await Engine.runAutoToFixpoint();
+    const r2 = await Engine.runAutoToFixpoint();
+    expect(r1.moves).toBe(1);
+    expect(r2.moves).toBe(0);
+    const hf = st.piles.foundations.find((f) => f.suit === 'H');
+    expect(hf.cards).toHaveLength(1);
+  });
+
+  test('reentrancy guard', async () => {
+    const st = build({ waste: ['H1'] });
+    const p1 = Engine.runAutoToFixpoint();
+    const p2 = Engine.runAutoToFixpoint();
+    const [r1, r2] = await Promise.all([p1, p2]);
+    const moves = [r1.moves, r2.moves].sort();
+    expect(moves).toEqual([0, 1]);
+    const hf = st.piles.foundations.find((f) => f.suit === 'H');
+    expect(hf.cards).toHaveLength(1);
+  });
+});

--- a/tests/auto.ui.spec.js
+++ b/tests/auto.ui.spec.js
@@ -1,0 +1,59 @@
+// Integration test validating Auto button UI behaviour
+import { describe, test, expect } from '@jest/globals';
+import fs from 'node:fs';
+import vm from 'node:vm';
+import { JSDOM } from 'jsdom';
+import { Engine } from './helpers/stateBuilder.js';
+
+describe('Auto UI integration', () => {
+  test('button disables during run and foundations update', async () => {
+    globalThis.AUTO_ANIMATE = false;
+    const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
+    const dom = new JSDOM(html, { pretendToBeVisual: true });
+    const { window } = dom;
+    const { document } = window;
+    const context = { window, document, console, setTimeout, clearTimeout };
+    context.window = window;
+    vm.createContext(context);
+    for (const file of ['js/emitter.js', 'js/model.js', 'js/engine.js', 'js/ui.js']) {
+      const code = fs.readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
+      vm.runInContext(code, context, { filename: file });
+    }
+    const { UI } = context.window;
+    Engine.on('state', (st) => UI.render(st));
+    UI.init(document.getElementById('game'));
+
+    const card = (s, r) => ({ id: s + r, rank: r, suit: s, color: ['H', 'D'].includes(s) ? 'red' : 'black', faceUp: true });
+    Engine.newGame({ drawCount: 1, redealPolicy: 'none', leftHandMode: false, animations: true, hints: true, autoComplete: true, sound: false });
+    const st = Engine.getState();
+    st.piles.foundations.find((f) => f.suit === 'S').cards = [card('S', 1), card('S', 2)];
+    st.piles.foundations.find((f) => f.suit === 'H').cards = [card('H', 1), card('H', 2)];
+    st.piles.foundations.find((f) => f.suit === 'D').cards = [card('D', 1), card('D', 2)];
+    st.piles.waste.cards = [card('S', 3)];
+    st.piles.tableau[0].cards = [card('D', 3)];
+    st.piles.tableau[1].cards = [card('H', 3)];
+    UI.render(st);
+
+    const order = [];
+    UI.animateMove = (mv) => new Promise((resolve) => {
+      order.push(mv.dstPileId);
+      setTimeout(resolve, 0);
+    });
+    const btn = document.getElementById('auto');
+    btn.addEventListener('click', async () => {
+      btn.disabled = true;
+      await Engine.runAutoToFixpoint();
+      btn.disabled = false;
+    });
+
+    btn.click();
+    expect(btn.disabled).toBe(true);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(btn.disabled).toBe(false);
+    expect(order).toEqual(['foundation-S', 'foundation-D', 'foundation-H']);
+    const hf = st.piles.foundations.find((f) => f.suit === 'H');
+    expect(hf.cards).toHaveLength(3);
+    const cardEl = document.querySelector('#foundation-H .card:last-child');
+    expect(cardEl.dataset.rank).toBe('3');
+  });
+});

--- a/tests/helpers/stateBuilder.js
+++ b/tests/helpers/stateBuilder.js
@@ -1,0 +1,83 @@
+import fs from 'node:fs';
+import vm from 'node:vm';
+
+// Shared VM context for loading engine and model once per test suite
+const context = { window: {}, console, setTimeout, clearTimeout };
+context.window = context;
+vm.createContext(context);
+for (const file of ['js/emitter.js', 'js/model.js', 'js/engine.js']) {
+  const code = fs.readFileSync(new URL(`../../${file}`, import.meta.url), 'utf8');
+  vm.runInContext(code, context, { filename: file });
+}
+
+const { Engine, Model } = context.window;
+
+// Minimal settings to keep tests deterministic and headless
+const TEST_SETTINGS = {
+  drawCount: 1,
+  redealPolicy: 'none',
+  leftHandMode: false,
+  animations: false,
+  hints: true,
+  autoComplete: true,
+  sound: false,
+};
+
+/**
+ * Parse a compact card code into a card object.
+ * Uppercase suit => face-up, lowercase => face-down.
+ * Example: 'H1' = A♥ face-up, 'd13' = K♦ face-down.
+ * @param {string} code
+ */
+function parseCard(code) {
+  const suit = code[0].toUpperCase();
+  const rank = Number(code.slice(1));
+  const faceUp = code[0] === suit;
+  return {
+    id: suit + rank,
+    rank,
+    suit,
+    color: Model.isRed(suit) ? 'red' : 'black',
+    faceUp,
+  };
+}
+
+/**
+ * Build a fresh engine state with the given pile contents.
+ * @param {{waste?:string[], tableau?:string[][], foundations?:Record<string,string[]>}} cfg
+ */
+function build(cfg = {}) {
+  const { waste = [], tableau = [], foundations = {} } = cfg;
+  Engine.newGame(TEST_SETTINGS);
+  const st = Engine.getState();
+
+  // Foundations keyed by suit; default to empty
+  st.piles.foundations = ['S', 'H', 'D', 'C'].map((suit) => ({
+    id: 'foundation-' + suit,
+    kind: 'foundation',
+    suit,
+    cards: (foundations[suit] || []).map(parseCard),
+  }));
+
+  // Waste pile
+  st.piles.waste = {
+    id: 'waste',
+    kind: 'waste',
+    cards: waste.map(parseCard),
+  };
+
+  // Tableau columns (7 fixed)
+  st.piles.tableau = Array.from({ length: 7 }, (_, i) => ({
+    id: 'tab-' + (i + 1),
+    kind: 'tableau',
+    col: i + 1,
+    cards: (tableau[i] || []).map(parseCard),
+  }));
+
+  // Empty stock to keep tests focused
+  st.piles.stock = { id: 'stock', kind: 'stock', cards: [] };
+
+  return st;
+}
+
+export { Engine, Model, build, parseCard };


### PR DESCRIPTION
## Summary
- add Jest-based unit and integration tests for Auto foundation moves
- document Auto behaviour and debug options
- log candidate moves in runAutoToFixpoint for DEBUG_AUTO

## Testing
- `npm run test:auto` *(fails: sh: 1: jest: not found)*
- `npm test` *(fails: Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'jsdom')*

------
https://chatgpt.com/codex/tasks/task_e_68bc130897548324b930743b9bbdf338