### PR TITLE
fix: shim EventEmitter and stabilize auto tests

### DIFF
--- a/js/engine.module.js
+++ b/js/engine.module.js
@@ -1,0 +1,12 @@
+// Engine wrapper for Node tests and environments without global EventEmitter.
+// Sets up globals expected by legacy scripts and re-exports Engine and Model.
+import { Emitter } from './utils/emitter.js';
+
+const g = globalThis;
+g.window ||= g;
+g.EventEmitter = Emitter;
+
+await import('./model.js');
+await import('./engine.js');
+
+export const { Engine, Model } = g;

--- a/js/utils/emitter.js
+++ b/js/utils/emitter.js
@@ -1,0 +1,20 @@
+// UMD-style adapter for both browser and Node.
+export class SimpleEmitter {
+  constructor(){ this._m = Object.create(null); }
+  on(t, f){ (this._m[t] ||= []).push(f); return this; }
+  off(t, f){ const a=this._m[t]; if (!a) return this; this._m[t]=a.filter(x=>x!==f); return this; }
+  once(t, f){ const g=(...args)=>{ this.off(t, g); f(...args); }; return this.on(t, g); }
+  emit(t, ...args){ const a=this._m[t]; if (!a) return false; for (const fn of [...a]) fn(...args); return a.length>0; }
+  removeAllListeners(t){ if (t) delete this._m[t]; else this._m = Object.create(null); }
+}
+
+// Prefer Node’s EventEmitter when available.
+let EmitterCtor = SimpleEmitter;
+try {
+  // Works in Node ESM tests; ignored in browsers.
+  // eslint-disable-next-line n/no-unsupported-features/es-syntax
+  const mod = await import('events');
+  if (mod?.EventEmitter) EmitterCtor = mod.EventEmitter;
+} catch { /* fall back */ }
+
+export const Emitter = EmitterCtor;

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test test/*.test.js",
+    "test": "node --test --import=./test/setup-globals.js test/*.test.js",
     "test:auto": "jest tests/auto.spec.js tests/auto.ui.spec.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",

--- a/test/auto-ace-button.integration.test.js
+++ b/test/auto-ace-button.integration.test.js
@@ -1,7 +1,6 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';
-import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
 
 // Integration test ensuring Auto moves an Ace from the waste pile
@@ -10,15 +9,12 @@ test('auto button moves waste Ace to foundation and re-enables', async () => {
   const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
   const dom = new JSDOM(html, { pretendToBeVisual: true });
   const { window } = dom;
-  const { document } = window;
-  const context = { window, document, console, setTimeout, clearTimeout };
-  context.window = window;
-  vm.createContext(context);
-  for (const file of ['js/emitter.js', 'js/model.js', 'js/engine.js', 'js/ui.js']) {
-    const code = fs.readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
-    vm.runInContext(code, context, { filename: file });
-  }
-  const { Engine, UI } = context.window;
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.navigator = window.navigator;
+  const { Engine } = await import('../js/engine.module.js');
+  await import('../js/ui.js');
+  const { UI } = globalThis;
   Engine.on('state', (st) => UI.render(st));
   UI.init(document.getElementById('game'));
 

--- a/test/auto-button.integration.test.js
+++ b/test/auto-button.integration.test.js
@@ -1,7 +1,6 @@
 import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 import fs from 'node:fs';
-import vm from 'node:vm';
 import { JSDOM } from 'jsdom';
 
 // Integration test for Auto button with sequential animations
@@ -10,15 +9,12 @@ test('Auto button disables during run and updates foundations', async () => {
   const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
   const dom = new JSDOM(html, { pretendToBeVisual: true });
   const { window } = dom;
-  const { document } = window;
-  const context = { window, document, console, setTimeout, clearTimeout };
-  context.window = window;
-  vm.createContext(context);
-  for (const file of ['js/emitter.js', 'js/model.js', 'js/engine.js', 'js/ui.js']) {
-    const code = fs.readFileSync(new URL(`../${file}`, import.meta.url), 'utf8');
-    vm.runInContext(code, context, { filename: file });
-  }
-  const { Engine, UI } = context.window;
+  globalThis.window = window;
+  globalThis.document = window.document;
+  globalThis.navigator = window.navigator;
+  const { Engine } = await import('../js/engine.module.js');
+  await import('../js/ui.js');
+  const { UI } = globalThis;
   Engine.on('state', (st) => UI.render(st));
   UI.init(document.getElementById('game'));
 

--- a/test/setup-globals.js
+++ b/test/setup-globals.js
@@ -1,0 +1,4 @@
+// Polyfills used by engine during tests
+if (typeof globalThis.requestAnimationFrame !== 'function') {
+  globalThis.requestAnimationFrame = (cb) => setTimeout(() => cb(Date.now()), 0);
+}


### PR DESCRIPTION
## Summary
- add environment-safe EventEmitter shim and wrapper for engine
- preload test polyfills and refactor auto integration tests to use module entry

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*
- `npm run test:coverage` *(fails: nyc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bc1e02d23883248f95da4aeb754a42