### PR TITLE
fix: guard Engine constructor for ESM use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Auto now moves Aces to empty suit foundations and includes comprehensive foundation tests
 - Auto runner guarded against re-entrancy and infinite loops
 - Auto runner id for pile was wrongly set to 'WASTE' instead of 'waste' (same for STOCK)
+- Engine constructor now safe across ESM and browser usage; exports standardized and call-form instantiation guarded
 
 ## [0.1.0] - 2025-09-03
 

--- a/js/engine.js
+++ b/js/engine.js
@@ -6,8 +6,12 @@
 (function () {
   "use strict";
 
-  const Engine = (() => {
-    const api = EventEmitter();
+  function Engine() {
+    // Allow construction without `new` by correcting the call form.
+    if (!(this instanceof Engine)) return new Engine();
+
+    // Support both function-style and class-style emitters.
+    const api = new EventEmitter();
     let state = null;
     let undoStack = [];
     let redoStack = [];
@@ -717,7 +721,11 @@
       _findNextFoundationMoves: findNextFoundationMoves,
       runAutoToFixpoint,
     };
-  })();
+  }
 
-  window.Engine = Engine;
+  // Pre-constructed singleton used by the browser code.
+  const engine = new Engine();
+  window.engine = engine;
+  window.Engine = engine; // backward compatibility
+  window.EngineCtor = Engine;
 })();

--- a/js/engine.module.js
+++ b/js/engine.module.js
@@ -9,4 +9,7 @@ g.EventEmitter = Emitter;
 await import('./model.js');
 await import('./engine.js');
 
-export const { Engine, Model } = g;
+// Export both the constructor and a pre-built singleton instance.
+export const Engine = g.EngineCtor;
+export const engine = g.Engine;
+export const Model = g.Model;

--- a/test/auto-ace-button.integration.test.js
+++ b/test/auto-ace-button.integration.test.js
@@ -12,15 +12,15 @@ test('auto button moves waste Ace to foundation and re-enables', async () => {
   globalThis.window = window;
   globalThis.document = window.document;
   globalThis.navigator = window.navigator;
-  const { Engine } = await import('../js/engine.module.js');
+  const { engine } = await import('../js/engine.module.js');
   await import('../js/ui.js');
   const { UI } = globalThis;
-  Engine.on('state', (st) => UI.render(st));
+  engine.on('state', (st) => UI.render(st));
   UI.init(document.getElementById('game'));
 
   const card = (s, r) => ({ id: s + r, rank: r, suit: s, color: ['H', 'D'].includes(s) ? 'red' : 'black', faceUp: true });
-  Engine.newGame({ drawCount: 1, redealPolicy: 'none', leftHandMode: false, animations: true, hints: true, autoComplete: true, sound: false });
-  const st = Engine.getState();
+  engine.newGame({ drawCount: 1, redealPolicy: 'none', leftHandMode: false, animations: true, hints: true, autoComplete: true, sound: false });
+  const st = engine.getState();
   st.piles.waste.cards = [card('H', 1)];
   st.piles.foundations.forEach((f) => (f.cards = []));
   UI.render(st);
@@ -28,7 +28,7 @@ test('auto button moves waste Ace to foundation and re-enables', async () => {
   const btn = document.getElementById('auto');
   btn.addEventListener('click', async () => {
     btn.disabled = true;
-    await Engine.runAutoToFixpoint();
+    await engine.runAutoToFixpoint();
     btn.disabled = false;
   });
 

--- a/test/auto-button.integration.test.js
+++ b/test/auto-button.integration.test.js
@@ -12,15 +12,15 @@ test('Auto button disables during run and updates foundations', async () => {
   globalThis.window = window;
   globalThis.document = window.document;
   globalThis.navigator = window.navigator;
-  const { Engine } = await import('../js/engine.module.js');
+  const { engine } = await import('../js/engine.module.js');
   await import('../js/ui.js');
   const { UI } = globalThis;
-  Engine.on('state', (st) => UI.render(st));
+  engine.on('state', (st) => UI.render(st));
   UI.init(document.getElementById('game'));
 
   const card = (s, r) => ({ id: s + r, rank: r, suit: s, color: ['H', 'D'].includes(s) ? 'red' : 'black', faceUp: true });
-  Engine.newGame({ drawCount: 1, redealPolicy: 'none', leftHandMode: false, animations: true, hints: true, autoComplete: true, sound: false });
-  const st = Engine.getState();
+  engine.newGame({ drawCount: 1, redealPolicy: 'none', leftHandMode: false, animations: true, hints: true, autoComplete: true, sound: false });
+  const st = engine.getState();
   st.piles.foundations.find((f) => f.suit === 'S').cards = [card('S', 1), card('S', 2)];
   st.piles.foundations.find((f) => f.suit === 'H').cards = [card('H', 1), card('H', 2)];
   st.piles.foundations.find((f) => f.suit === 'D').cards = [card('D', 1), card('D', 2)];
@@ -38,7 +38,7 @@ test('Auto button disables during run and updates foundations', async () => {
   const btn = document.getElementById('auto');
   btn.addEventListener('click', async () => {
     btn.disabled = true;
-    await Engine.runAutoToFixpoint();
+    await engine.runAutoToFixpoint();
     btn.disabled = false;
   });
 

--- a/test/engine-instantiation.test.js
+++ b/test/engine-instantiation.test.js
@@ -1,0 +1,12 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { Engine } from '../js/engine.module.js';
+
+// Ensure calling Engine without `new` returns a working instance.
+test('Engine constructor guard', () => {
+  const inst = Engine();
+  assert.equal(typeof inst.newGame, 'function');
+  // Should be distinct instances on each call
+  const inst2 = Engine();
+  assert.notStrictEqual(inst, inst2);
+});


### PR DESCRIPTION
## Summary
- ensure Engine creates an EventEmitter with `new` and auto-corrects missing `new`
- export Engine constructor and singleton from engine.module.js
- update integration tests and add regression test for constructor guard
- document safe Engine instantiation in changelog

## Testing
- `npm test` *(fails: Cannot find package 'jsdom')*
- `npm run test:coverage` *(fails: nyc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bcc3e08c008324aa2219da0e430097