### PR TITLE
fix: preserve emitter API on Engine instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - Auto runner guarded against re-entrancy and infinite loops
 - Auto runner id for pile was wrongly set to 'WASTE' instead of 'waste' (same for STOCK)
 - Engine constructor now safe across ESM and browser usage; exports standardized and call-form instantiation guarded
+- Engine retains EventEmitter listener methods to avoid `engine.on` errors
 
 ## [0.1.0] - 2025-09-03
 

--- a/js/engine.js
+++ b/js/engine.js
@@ -697,8 +697,12 @@
       }
     }
 
-    return {
-      ...api,
+    // Augment the EventEmitter instance with the engine's public API.
+    // Using Object.assign preserves emitter methods (on, emit, etc.)
+    // which live on the prototype and are non-enumerable in Node's
+    // implementation. Spreading `api` into a new object would lose
+    // these methods and break event handling in consumers.
+    Object.assign(api, {
       newGame,
       getState,
       draw,
@@ -720,7 +724,8 @@
       _stateHash: stateHash,
       _findNextFoundationMoves: findNextFoundationMoves,
       runAutoToFixpoint,
-    };
+    });
+    return api;
   }
 
   // Pre-constructed singleton used by the browser code.

--- a/test/engine-eventemitter.test.js
+++ b/test/engine-eventemitter.test.js
@@ -1,0 +1,16 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+import { Engine, engine } from '../js/engine.module.js';
+
+// Ensure returned engine APIs keep EventEmitter listener methods.
+// Regression test for spreading EventEmitter into a plain object.
+test('engine exposes EventEmitter methods', () => {
+  assert.equal(typeof engine.on, 'function');
+  assert.equal(typeof engine.emit, 'function');
+});
+
+test('Engine constructor returns emitter-capable instance', () => {
+  const inst = Engine();
+  assert.equal(typeof inst.on, 'function');
+  assert.equal(typeof inst.emit, 'function');
+});


### PR DESCRIPTION
## Summary
- ensure Engine's returned object retains EventEmitter methods
- document fix in changelog
- test that Engine and singleton expose EventEmitter listener API

## Testing
- `node --test --import=./test/setup-globals.js test/engine-eventemitter.test.js`
- `npm test` *(fails: Cannot find package 'jsdom')*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config)*

------
https://chatgpt.com/codex/tasks/task_e_68bcce825cfc832482aef8ebb805b388